### PR TITLE
symmetry in G_mRRHO

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -203,7 +203,7 @@ a replacement solvent. E.g. if CCl4 is not available choose CHCl3.
 .. raw:: html
 
     <p align="center">
-    <img src="docs/src/solvents.png" alt="censo_solvents.json" width="800">
+    <img src="docs/src/solvents.png" alt="censo_solvents.json" width="700">
     </p>
 
 The solvent file is directly used in `CENSO` and typos will cause calculations to crash!

--- a/censo_qm/censo.py
+++ b/censo_qm/censo.py
@@ -62,6 +62,7 @@ def main(argv=None):
             sys.exit(1)
         toc = perf_counter()
         ensembledata.part_info["part0"] = toc - tic
+        ensembledata.previous_part_info["part0"] +=  ensembledata.part_info["part0"]
         print(f"Ran part0 in {ensembledata.part_info['part0']:0.4f} seconds")
 
     # RUNNING PART1
@@ -85,6 +86,8 @@ def main(argv=None):
             sys.exit(1)
         toc = perf_counter()
         ensembledata.part_info["part1"] = toc - tic
+        ensembledata.previous_part_info["part1"] += ensembledata.part_info["part1"]
+        ensembledata.previous_part_info["part1_firstsort"] += ensembledata.part_info["part1_firstsort"]
         print(f"Ran part1 in {ensembledata.part_info['part1']:0.4f} seconds")
 
     # RUNNING PART2
@@ -108,6 +111,8 @@ def main(argv=None):
             sys.exit(1)
         toc = perf_counter()
         ensembledata.part_info["part2"] = toc - tic
+        ensembledata.previous_part_info["part2"] += ensembledata.part_info["part2"]
+        ensembledata.previous_part_info["part2_opt"] += ensembledata.part_info["part2_opt"]
         print(f"Ran part2 in {ensembledata.part_info['part2']:0.4f} seconds")
 
     # RUNNING PART3
@@ -131,6 +136,7 @@ def main(argv=None):
             sys.exit(1)
         toc = perf_counter()
         ensembledata.part_info["part3"] = toc - tic
+        ensembledata.previous_part_info["part3"] += ensembledata.part_info["part3"]
         print(f"Ran part3 in {ensembledata.part_info['part3']:0.4f} seconds")
 
     # RUNNING PART4
@@ -154,6 +160,7 @@ def main(argv=None):
             sys.exit(1)
         toc = perf_counter()
         ensembledata.part_info["part4"] = toc - tic
+        ensembledata.previous_part_info["part4"] += ensembledata.part_info["part4"]
         print(f"Ran part4 in {ensembledata.part_info['part4']:0.4f} seconds")
 
     # RUNNING PART5
@@ -177,6 +184,7 @@ def main(argv=None):
             sys.exit(1)
         toc = perf_counter()
         ensembledata.part_info["part5"] = toc - tic
+        ensembledata.previous_part_info["part5"] += ensembledata.part_info["part5"]
         print(f"Ran part5 in {ensembledata.part_info['part5']:0.4f} seconds")
 
     # save current data to jsonfile
@@ -190,51 +198,91 @@ def main(argv=None):
 
     # END of CENSO
     timings = 0.0
+    prev_timings = 0.0
     if len(str(config.nconf)) > 5:
         conflength = len(str(config.nconf))
     else:
         conflength = 5
 
-    print(f"\n\n{'Part':20}: {'#conf':>{conflength}}    time")
-    print("".ljust(int(PLENGTH / 2), "-"))
-    print(f"{'Input':20}: {ensembledata.nconfs_per_part['starting']:{conflength}}    -")
+    try:
+        tmp = []
+        tmp_prev = []
+        if config.part0:
+            tmp.append(ensembledata.part_info['part0'])
+            tmp_prev.append(ensembledata.previous_part_info['part0'])
+        if config.part1:
+            tmp.append(ensembledata.part_info['part1'])
+            tmp_prev.append(ensembledata.previous_part_info['part1'])
+            tmp_prev.append(ensembledata.previous_part_info['part1_firstsort'])
+        if config.part2:
+            tmp.append(ensembledata.part_info['part2'])
+            tmp_prev.append(ensembledata.previous_part_info['part2'])
+            tmp.append(ensembledata.part_info['part2_opt'])
+            tmp_prev.append(ensembledata.previous_part_info['part2_opt'])
+        if config.part3:
+            tmp.append(ensembledata.part_info['part3'])
+            tmp_prev.append(ensembledata.previous_part_info['part3'])
+        if config.part4:
+            tmp.append(ensembledata.part_info['part4'])
+            tmp_prev.append(ensembledata.previous_part_info['part4'])
+        if config.optical_rotation:
+            tmp.append(ensembledata.part_info['part5'])             
+            tmp_prev.append(ensembledata.previous_part_info['part5'])
+        timelen = max([len(f"{float(value):.2f}") for value in tmp]) +2
+        prev_timelen = max([len(f"{float(value):.2f}") for value in tmp_prev]) +2
+        if timelen < 7:
+            timelen = 7
+    except Exception:
+        timelen = 20
+        prev_timelen = 20
+
+
+    print(f"\n\n{'Part':20}: {'#conf':>{conflength}}    {'time': >{timelen}}      time (including restarts)")
+    print("".ljust(int(PLENGTH/1.4), "-"))
+    print(f"{'Input':20}: {ensembledata.nconfs_per_part['starting']:{conflength}}    {'-':^{timelen+2}}    {'-':^{timelen+2}}")
     if config.part0:
         print(
-            f"{'Part0_all':20}: {ensembledata.nconfs_per_part['part0']:{conflength}}    {ensembledata.part_info['part0']:.2f} s"
+            f"{'Part0_all':20}: {ensembledata.nconfs_per_part['part0']:{conflength}}    {ensembledata.part_info['part0']:{timelen}.2f} s  {ensembledata.previous_part_info['part0']:>{prev_timelen}.2f} s"
         )
         timings += ensembledata.part_info["part0"]
+        prev_timings += ensembledata.previous_part_info['part0']
     if config.part1:
         print(
-            f"{'Part1_initial_sort':20}: {ensembledata.nconfs_per_part['part1_firstsort']:{conflength}}    -"
+            f"{'Part1_initial_sort':20}: {ensembledata.nconfs_per_part['part1_firstsort']:{conflength}}    {ensembledata.part_info['part1_firstsort']:{timelen}.2f} s  {ensembledata.previous_part_info['part1_firstsort']:>{prev_timelen}.2f} s"
         )
         print(
-            f"{'Part1_all':20}: {ensembledata.nconfs_per_part['part1_firstsort']:{conflength}}    {ensembledata.part_info['part1']:.2f} s"
+            f"{'Part1_all':20}: {ensembledata.nconfs_per_part['part1_firstsort']:{conflength}}    {ensembledata.part_info['part1']:{timelen}.2f} s  {ensembledata.previous_part_info['part1']:>{prev_timelen}.2f} s"
         )
         timings += ensembledata.part_info["part1"]
+        prev_timings += ensembledata.previous_part_info['part1']
     if config.part2:
         print(
-            f"{'Part2_opt':20}: {ensembledata.nconfs_per_part['part2_opt']:{conflength}}    -"
+            f"{'Part2_opt':20}: {ensembledata.nconfs_per_part['part2_opt']:{conflength}}    {ensembledata.part_info['part2_opt']:{timelen}.2f} s  {ensembledata.previous_part_info['part2_opt']:>{prev_timelen}.2f} s"
         )
         print(
-            f"{'Part2_all':20}: {ensembledata.nconfs_per_part['part2']:{conflength}}    {ensembledata.part_info['part2']:.2f} s"
+            f"{'Part2_all':20}: {ensembledata.nconfs_per_part['part2']:{conflength}}    {ensembledata.part_info['part2']:{timelen}.2f} s  {ensembledata.previous_part_info['part2']:>{prev_timelen}.2f} s"
         )
         timings += ensembledata.part_info["part2"]
+        prev_timings += ensembledata.previous_part_info['part2']
     if config.part3:
         print(
-            f"{'Part3_all':20}: {ensembledata.nconfs_per_part['part3']:{conflength}}    {ensembledata.part_info['part3']:.2f} s"
+            f"{'Part3_all':20}: {ensembledata.nconfs_per_part['part3']:{conflength}}    {ensembledata.part_info['part3']:{timelen}.2f} s  {ensembledata.previous_part_info['part3']:>{prev_timelen}.2f} s"
         )
         timings += ensembledata.part_info["part3"]
+        prev_timings += ensembledata.previous_part_info['part3']
     if config.part4:
         print(
-            f"{'Part4':20}: {'':{conflength}}    {ensembledata.part_info['part4']:.2f} s"
+            f"{'Part4':20}: {'':{conflength}}    {ensembledata.part_info['part4']:{timelen}.2f} s  {ensembledata.previous_part_info['part4']:>{prev_timelen}.2f} s"
         )
         timings += ensembledata.part_info["part4"]
+        prev_timings += ensembledata.previous_part_info['part4']
     if config.optical_rotation:
         print(
-            f"{'Part5':20}: {'':{conflength}}    {ensembledata.part_info['part5']:.2f} s"
+            f"{'Part5':20}: {'':{conflength}}    {ensembledata.part_info['part5']:{timelen}.2f} s  {ensembledata.previous_part_info['part5']:>{prev_timelen}.2f} s"
         )
         timings += ensembledata.part_info["part5"]
-    print("".ljust(int(PLENGTH / 2), "-"))
-    print(f"{'All parts':20}: {'':{conflength}}    {timings:.2f} s")
+        prev_timings += ensembledata.previous_part_info['part5']
+    print("".ljust(int(PLENGTH / 1.4), "-"))
+    print(f"{'All parts':20}: {'-':>{conflength}}    {timings:{timelen}.2f} s  {prev_timings:{prev_timelen}.2f} s")
     print("\nCENSO all done!")
     return 0

--- a/censo_qm/cfg.py
+++ b/censo_qm/cfg.py
@@ -5,7 +5,7 @@ Storing censo_solvent_db solvent database across all solvation models (as fallba
 """
 import os
 
-__version__ = "1.0.7"
+__version__ = "1.0.8"
 
 DESCR = f"""
          ______________________________________________________________
@@ -37,6 +37,7 @@ DIGILEN = 60
 PLENGTH = 100
 AU2J = 4.3597482e-18  # a.u.(hartree/mol) to J
 KB = 1.3806485279e-23  # J/K
+R = 1.987203585e-03  # kcal/(mol*K)
 AU2KCAL = 627.50947428
 BOHR2ANG = 0.52917721067
 WARNLEN = max([len(i) for i in ['WARNING:', 'ERROR:', 'INFORMATION:']])+1
@@ -2654,3 +2655,39 @@ class NmrRef():
         NmrRef_object.si_orca_shieldings = dictionary.get('si_orca_shieldings', NmrRef_object.si_orca_shieldings)
         NmrRef_object.p_orca_shieldings = dictionary.get('p_orca_shieldings', NmrRef_object.p_orca_shieldings)
         return NmrRef_object
+
+# rotational entropy from symmetry
+#https://cccbdb.nist.gov/thermo.asp
+rot_sym_num = {
+    'c1':1,
+    'ci':1,
+    'cs':1,
+    'c2':2,
+    'c3':3,
+    'c4':4,
+    'c5':5,
+    'c6':6,
+    'c7':7,
+    'c8':8,
+    'c9':9,
+    'c10':10,
+    'c11':11,
+    's4':2,
+    's6':3,
+    's8':4,
+    'd2':4,
+    'd3':6,
+    'd4':8,
+    'd5':10,
+    'd6':12,
+    'd7':14,
+    'd8':16,
+    'd9':18,
+    'd10':20,
+    't':12,
+    'th': 12,
+    'td': 12,
+    'o': 24,
+    'oh':24,
+    'ih':60
+}

--- a/censo_qm/cheapscreening.py
+++ b/censo_qm/cheapscreening.py
@@ -259,6 +259,7 @@ def part0(config, conformers, ensembledata):
                     conf.cheap_prescreening_sp_info["info"] = "calculated"
                     conf.cheap_prescreening_sp_info["method"] = conf.job["method"]
                     conf.cheap_prescreening_gsolv_info["energy"] = conf.job["energy2"]
+                    conf.cheap_prescreening_gsolv_info["range"] = {config.temperature: conf.job['energy2'],}
                     conf.cheap_prescreening_gsolv_info["info"] = "calculated"
                     conf.cheap_prescreening_gsolv_info["method"] = conf.job["method2"]
                     conf.cheap_prescreening_gsolv_info["gas-energy"] = conf.job[
@@ -345,7 +346,13 @@ def part0(config, conformers, ensembledata):
     rrho = None
     energy = "cheap_prescreening_sp_info"
     for conf in calculate:
-        conf.calc_free_energy(e=energy, solv=solvation, rrho=rrho)
+        conf.calc_free_energy(
+            e=energy,
+            solv=solvation,
+            rrho=rrho,
+            t=config.temperature,
+            consider_sym=config.consider_sym
+            )
     try:
         minfree = min([i.free_energy for i in calculate if i is not None])
     except ValueError:
@@ -428,8 +435,8 @@ def part0(config, conformers, ensembledata):
         (5, 2),
         (5, 2),
     ]
-    columndescription[1] = f"{config.part0_gfnv.upper()}-xTB[{config.sm_rrho.upper()}]"
-    columndescription[2] = f"{config.part0_gfnv.upper()}-xTB[{config.sm_rrho.upper()}]"
+    columndescription[1] = f"{config.part0_gfnv.upper()}-xTB[{config.sm_rrho}]"
+    columndescription[2] = f"{config.part0_gfnv.upper()}-xTB[{config.sm_rrho}]"
     columndescription[3] = instruction["method"]
     columndescription[4] = instruction["method2"]
     if config.solvent == "gas":

--- a/censo_qm/ensembledata.py
+++ b/censo_qm/ensembledata.py
@@ -10,6 +10,18 @@ class EnsembleData:
             "part2_opt": None,
             "part2": None,
             "part3": None,
+            "part4": None,
+            "part5": None,
+        },
+        previous_part_info={
+            "part0": 0.0,
+            "part1_firstsort": 0.0,
+            "part1": 0.0,
+            "part2_opt": 0.0,
+            "part2": 0.0,
+            "part3": 0.0,
+            "part4": 0.0,
+            "part5": 0.0,
         },
         avGcorrection=None,
         comment=None,
@@ -42,6 +54,7 @@ class EnsembleData:
         self.id = id
         self.filename = filename
         self.part_info = part_info
+        self.previous_part_info = previous_part_info
         self.avGcorrection = avGcorrection
         self.comment = comment
         self.bestconf = bestconf

--- a/censo_qm/tm_job.py
+++ b/censo_qm/tm_job.py
@@ -746,7 +746,6 @@ class TmJob(QmJob):
                 ) as inp:
                     stor = inp.readlines()
                 for line in stor:
-                    #vwork = 0
                     if "T=" in line:
                         T = float(line.split()[5])
                         vwork = R * T * math.log(videal * T)

--- a/censo_qm/utilities.py
+++ b/censo_qm/utilities.py
@@ -172,7 +172,7 @@ def x2t(path, infile="inp.xyz"):
 
 
 def write_trj(
-    results, cwd, outpath, optfolder, nat, attribute, overwrite=False, *args, **kwargs
+    results, cwd, outpath, optfolder, nat, attribute, temperature, consider_sym, overwrite=False, *args, **kwargs
 ):
     """
     Write trajectory (multiple xyz geometries) to file.
@@ -199,8 +199,13 @@ def write_trj(
                 ### coordinates in xyz
                 out.write("  {}\n".format(nat))
                 xtbfree = conf.calc_free_energy(
-                    e=energy, solv=None, rrho=rrho, out=True
-                )
+                    e=energy, 
+                    solv=None,
+                    rrho=rrho,
+                    out=True,
+                    t=temperature,
+                    consider_sym=consider_sym
+                    )
                 if xtbfree is not None:
                     xtbfree = f"{xtbfree:20.8f}"
                 out.write(
@@ -779,8 +784,13 @@ def crest_routine(config, conformers, func, store_confs, prev_calculated=None):
 def format_line(key, value, options, optionlength=70, dist_to_options=30):
     """
     used in print_parameters
+    'key: value ---space--- #(separator) option1 option2 ...'
     """
     # limit printout of possibilities
+    if len(options) > 0:
+        separator = '#'
+    else:
+        separator = ''
     if len(str(options)) > optionlength:
         length = 0
         reduced = []
@@ -790,8 +800,8 @@ def format_line(key, value, options, optionlength=70, dist_to_options=30):
                 reduced.append(item)
         reduced.append("...")
         options = reduced
-    line = "{}: {:{digits}} # {} \n".format(
-        key, str(value), options, digits=dist_to_options - len(key)
+    line = "{}: {:{digits}} {} {} \n".format(
+        key, str(value), separator, options, digits=dist_to_options - len(key)
     )
     return line
 


### PR DESCRIPTION
• better time printout, which also includes restarts
• symmetry in the G_mRRHO contribution is always detected, but its contribution to S_rot can be switched on and off by CENSO  -consider_sym without the need to recalculate
• if new censorc remote configuration files are created and an existing .censorc is found the program paths can be copied to the new censorc
• printout of OR data to file
• printout of NMR data to file
• new option to creat a censo.inp file from all settings set by command line
• SASA grid for ALPB and GBSA increased