### PR TITLE
Ancopt charge documentation

### DIFF
--- a/censo_qm/cfg.py
+++ b/censo_qm/cfg.py
@@ -6,7 +6,7 @@ Storing censo_solvent_db solvent database across all solvation models (as fallba
 import os
 import sys
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 DESCR = f"""
          ______________________________________________________________

--- a/censo_qm/orca_job.py
+++ b/censo_qm/orca_job.py
@@ -637,6 +637,12 @@ class OrcaJob(QmJob):
                 "-I",
                 "opt.inp",
             ]
+            # update unpaired electrons
+            if int(self.job["unpaired"]) > 0:
+                callargs = callargs + ["--uhf", str(self.job["unpaired"])]
+            # update charge:
+            if int(self.job["charge"]) != 0:
+                callargs = callargs + ["--chrg", str(self.job["charge"])]        
             with open(
                 os.path.join(self.job["workdir"], "opt.inp"), "w", newline=None
             ) as out:

--- a/censo_qm/tm_job.py
+++ b/censo_qm/tm_job.py
@@ -950,6 +950,13 @@ class TmJob(QmJob):
                 self.job["optlevel"],
                 "--tm",
             ]
+            # update unpaired electrons
+            if int(self.job["unpaired"]) > 0:
+                callargs = callargs + ["--uhf", str(self.job["unpaired"])]
+            # update charge:
+            if int(self.job["charge"]) != 0:
+            callargs = callargs + ["--chrg", str(self.job["charge"])]
+
             with open(
                 os.path.join(self.job["workdir"], "opt.inp"), "w", newline=None
             ) as out:

--- a/censo_qm/tm_job.py
+++ b/censo_qm/tm_job.py
@@ -955,7 +955,7 @@ class TmJob(QmJob):
                 callargs = callargs + ["--uhf", str(self.job["unpaired"])]
             # update charge:
             if int(self.job["charge"]) != 0:
-            callargs = callargs + ["--chrg", str(self.job["charge"])]
+                callargs = callargs + ["--chrg", str(self.job["charge"])]
 
             with open(
                 os.path.join(self.job["workdir"], "opt.inp"), "w", newline=None


### PR DESCRIPTION
Provide charge and uhf information to xtb for consistency reasons, when xtb is only used as a driver for ancopt and external QM code. The charge and uhf information is not used when xtb is used as a driver for ANCopt with external QM code.
External code has the correct charge and unpaired electron information.