### PR TITLE
dfa.json cleanup and fixed ORCA problems with *-novdw functionals

### DIFF
--- a/src/censo/assets/dfa.json
+++ b/src/censo/assets/dfa.json
@@ -41,27 +41,72 @@
     "disp": "d4",
     "type": "mgga"
   },
-  "pbe-novdw": { "tm": "pbe", "orca": "pbe", "disp": "novdw", "type": "gga" },
-  "pbe-d3": { "tm": "pbe", "orca": "pbe", "disp": "d3bj", "type": "gga" },
-  "pbe-d3(0)": { "tm": "pbe", "orca": "pbe", "disp": "d3(0)", "type": "gga" },
-  "pbe-d4": { "tm": "pbe", "orca": "pbe", "disp": "d4", "type": "gga" },
-  "pbe-nl": { "tm": "pbe", "disp": "nl", "type": "gga" },
-  "bp86": { "tm": "b-p", "disp": "novdw", "type": "gga" },
+  "pbe-novdw": {
+    "tm": "pbe",
+    "orca": "pbe",
+    "disp": "novdw",
+    "type": "gga"
+  },
+  "pbe-d3": {
+    "tm": "pbe",
+    "orca": "pbe",
+    "disp": "d3bj",
+    "type": "gga"
+  },
+  "pbe-d3(0)": {
+    "tm": "pbe",
+    "orca": "pbe",
+    "disp": "d3(0)",
+    "type": "gga"
+  },
+  "pbe-d4": {
+    "tm": "pbe",
+    "orca": "pbe",
+    "disp": "d4",
+    "type": "gga"
+  },
+  "pbe-nl": {
+    "tm": "pbe",
+    "orca": "pbe",
+    "disp": "nl",
+    "type": "gga"
+  },
+  "bp86": {
+    "tm": "b-p",
+    "orca": "bp86",
+    "disp": "novdw",
+    "type": "gga"
+  },
   "tpss-novdw": {
     "tm": "tpss",
     "orca": "tpss",
     "disp": "novdw",
     "type": "mgga"
   },
-  "tpss-d3": { "tm": "tpss", "orca": "tpss", "disp": "d3bj", "type": "mgga" },
+  "tpss-d3": {
+    "tm": "tpss",
+    "orca": "tpss",
+    "disp": "d3bj",
+    "type": "mgga"
+  },
   "tpss-d3(0)": {
     "tm": "tpss",
     "orca": "tpss",
     "disp": "d3(0)",
     "type": "mgga"
   },
-  "tpss-d4": { "tm": "tpss", "orca": "tpss", "disp": "d4", "type": "mgga" },
-  "tpss-nl": { "tm": "tpss", "disp": "nl", "type": "mgga" },
+  "tpss-d4": {
+    "tm": "tpss",
+    "orca": "tpss",
+    "disp": "d4",
+    "type": "mgga"
+  },
+  "tpss-nl": {
+    "tm": "tpss",
+    "orca": "tpss",
+    "disp": "nl",
+    "type": "mgga"
+  },
   "revtpss-novdw": {
     "tm": "revtpss",
     "orca": "revTPSS",
@@ -73,22 +118,43 @@
     "disp": "novdw",
     "type": "global_hybrid"
   },
-  "tpssh-d3": { "orca": "tpssh", "disp": "d3", "type": "global_hybrid" },
+  "tpssh-d3": {
+    "orca": "tpssh",
+    "disp": "d3bj",
+    "type": "global_hybrid"
+  },
   "tpssh-d3(0)": {
     "orca": "tpssh",
     "disp": "d3(0)",
     "type": "global_hybrid"
   },
-  "tpssh-d4": { "orca": "tpssh", "disp": "d4", "type": "global_hybrid" },
+  "tpssh-d4": {
+    "orca": "tpssh",
+    "disp": "d4",
+    "type": "global_hybrid"
+  },
   "b97-d3": {
     "tm": "b97-d",
     "orca": "b97-d3",
     "disp": "included",
     "type": "gga"
   },
-  "b97-d4": { "orca": "b97-d4", "disp": "included", "type": "gga" },
-  "kt1-novdw": { "tm": "kt1", "disp": "novdw", "type": "gga" },
-  "kt2-novdw": { "tm": "kt2", "orca": "kt2", "disp": "novdw", "type": "gga" },
+  "b97-d4": {
+    "orca": "b97-d4",
+    "disp": "included",
+    "type": "gga"
+  },
+  "kt1-novdw": {
+    "tm": "kt1",
+    "disp": "novdw",
+    "type": "gga"
+  },
+  "kt2-novdw": {
+    "tm": "kt2",
+    "orca": "kt2",
+    "disp": "novdw",
+    "type": "gga"
+  },
   "pbe0-novdw": {
     "tm": "pbe0",
     "orca": "pbe0",
@@ -113,7 +179,12 @@
     "disp": "d4",
     "type": "global_hybrid"
   },
-  "pbe0-nl": { "tm": "pbe0", "disp": "nl", "type": "global_hybrid" },
+  "pbe0-nl": {
+    "tm": "pbe0",
+    "orca": "pbe0",
+    "disp": "nl",
+    "type": "global_hybrid"
+  },
   "pw6b95-novdw": {
     "tm": "pw6b95",
     "orca": "pw6b95",

--- a/src/censo/processing/orca_processor.py
+++ b/src/censo/processing/orca_processor.py
@@ -227,6 +227,7 @@ class OrcaProc(QmProc):
             "d3(0)": "D3ZERO",
             "d4": "d4",
             "nl": "NL",
+            "novdw": "",
         }
 
         if disp != "composite" and disp != "included":


### PR DESCRIPTION
Hey Lukas here!
I cleaned up the dfa.json file a little bit. Mainly adding orca entries for functionals that should work with ORCA (all -novdw and all -nl functionals).
I also added an additional mapping for all -novdw DFA functionals in the orca_processor, so that for these func keywords ORCA uses just the plain functional.
All functionals with NL dispersion now work with orca 5.0.4 and 6.1.1, I didn't go further back though.