### PR TITLE
add gxtb as method for xtb helper functions

### DIFF
--- a/src/censo/config/parts_config.py
+++ b/src/censo/config/parts_config.py
@@ -125,9 +125,23 @@ class PartsConfig(GenericConfig):
         """
         Call attribute validators.
         """
+        gxtb_used = False
         for name, part in parts_to_check:
-            checked = part.model_validate(part)
+            checked = part.model_validate(part.model_dump())
             setattr(self, name, checked)
+            if (
+                name == "prescreening"
+                and not self.general.gas_phase
+                and getattr(checked, "gfnv", None) == "gxtb"
+            ):
+                raise ValueError("gxtb does not support solvation currently.")
+            if getattr(checked, "gfnv", None) == "gxtb":
+                gxtb_used = True
+
+        if not self.general.gas_phase and gxtb_used:
+            warnings.warn(
+                "gxtb does not support solvation currently. xtb calls with gxtb will not include solvation effects."
+            )
 
     # SOLVENT/SM VALIDATION
     # NOTE: since solvent is a general settings this is validated here because we need access

--- a/src/censo/config/setup.py
+++ b/src/censo/config/setup.py
@@ -89,7 +89,9 @@ def configure(
             parts_config.general.__setattr__(field, setting)
 
     # Revalidate after command line args incl. solvents and paths with context
-    parts_config = PartsConfig.model_validate(parts_config, context=context)
+    parts_config = PartsConfig.model_validate(
+        parts_config.model_dump(), context=context
+    )
 
     return parts_config
 

--- a/src/censo/ensembleopt/optimization.py
+++ b/src/censo/ensembleopt/optimization.py
@@ -53,7 +53,9 @@ def optimization(
     """
     printf(h2("OPTIMIZATION"))
 
-    config = PartsConfig.model_validate(config, context={"check": ["optimization"]})
+    config = PartsConfig.model_validate(
+        config.model_dump(), context={"check": ["optimization"]}
+    )
 
     # Setup processor
     proc = Factory[QmProc].create(config.optimization.prog, "2_OPTIMIZATION")

--- a/src/censo/ensembleopt/prescreening.py
+++ b/src/censo/ensembleopt/prescreening.py
@@ -45,7 +45,9 @@ def prescreening(
     """
     printf(h2("PRESCREENING"))
 
-    config = PartsConfig.model_validate(config, context={"check": ["prescreening"]})
+    config = PartsConfig.model_validate(
+        config.model_dump(), context={"check": ["prescreening"]}
+    )
 
     # Setup processor and target
     proc = Factory[QmProc].create(config.prescreening.prog, "0_PRESCREENING")

--- a/src/censo/ensembleopt/refinement.py
+++ b/src/censo/ensembleopt/refinement.py
@@ -36,7 +36,9 @@ def refinement(
     """
     printf(h2("REFINEMENT"))
 
-    config = PartsConfig.model_validate(config, context={"check": ["refinement"]})
+    config = PartsConfig.model_validate(
+        config.model_dump(), context={"check": ["refinement"]}
+    )
 
     # Setup processor and target
     proc = Factory[QmProc].create(config.refinement.prog, "3_REFINEMENT")

--- a/src/censo/ensembleopt/screening.py
+++ b/src/censo/ensembleopt/screening.py
@@ -53,7 +53,9 @@ def screening(
     """
     printf(h2("SCREENING"))
 
-    config = PartsConfig.model_validate(config, context={"check": ["screening"]})
+    config = PartsConfig.model_validate(
+        config.model_dump(), context={"check": ["screening"]}
+    )
 
     # Setup processor and target
     proc = Factory[QmProc].create(config.screening.prog, "1_SCREENING")

--- a/src/censo/params.py
+++ b/src/censo/params.py
@@ -91,6 +91,7 @@ class GfnVersion(str, Enum):
     GFNFF = "gfnff"
     GFN1 = "gfn1"
     GFN2 = "gfn2"
+    GXTB = "gxtb"
 
 
 class Prog(str, Enum):

--- a/src/censo/processing/xtb_processor.py
+++ b/src/censo/processing/xtb_processor.py
@@ -329,6 +329,7 @@ class XtbProc(GenericProc):
             xcontrolname,
             "--parallel",
             f"{job.omp}",
+            "--acc=0.1",
         ]
 
         # add solvent to xtb call if necessary

--- a/src/censo/processing/xtb_processor.py
+++ b/src/censo/processing/xtb_processor.py
@@ -110,7 +110,8 @@ class XtbProc(GenericProc):
         ]
 
         # add solvent to xtb call if not a gas-phase sp
-        if not no_solv and not config.gas_phase:
+        # NOTE: gxtb has no solvation currently
+        if not no_solv and not config.gas_phase and config.gfnv != "gxtb":
             assert config.solvent
             assert config.sm_rrho
             solvent_key = SOLVENTS[config.solvent][config.sm_rrho]
@@ -176,8 +177,14 @@ class XtbProc(GenericProc):
         :returns: Tuple of (GsolvResult, MetaData)
         :rtype: tuple[GsolvResult, MetaData]
         """
+
         result = GsolvResult()
         meta = MetaData(job.conf.name)
+
+        if config.gfnv == "gxtb":
+            meta.success = False
+            meta.error = "gxtb does not support solvation currently"
+            return result, meta
 
         jobdir = self._setup(job, "xtb_gsolv")
 
@@ -325,7 +332,7 @@ class XtbProc(GenericProc):
         ]
 
         # add solvent to xtb call if necessary
-        if not config.gas_phase:
+        if not config.gas_phase and config.gfnv != "gxtb":
             assert config.solvent
             assert config.sm_rrho
             solvent_key = SOLVENTS[config.solvent][config.sm_rrho]

--- a/src/censo/properties/nmr.py
+++ b/src/censo/properties/nmr.py
@@ -40,7 +40,7 @@ def nmr(
     """
     printf(h2("NMR"))
 
-    config = PartsConfig.model_validate(config, context={"check": ["nmr"]})
+    config = PartsConfig.model_validate(config.model_dump(), context={"check": ["nmr"]})
 
     # Assert that all conformers have energies defined
     # TODO: this is not optimal since == 0 does not mean that no ensembleopt has been performed before

--- a/src/censo/properties/rot.py
+++ b/src/censo/properties/rot.py
@@ -38,7 +38,7 @@ def rot(
     """
     printf(h2("ROT"))
 
-    config = PartsConfig.model_validate(config, context={"check": ["rot"]})
+    config = PartsConfig.model_validate(config.model_dump(), context={"check": ["rot"]})
 
     # Assert that all conformers have energies defined
     # TODO: this is not optimal since == 0 does not mean that no ensembleopt has been performed before

--- a/src/censo/properties/uvvis.py
+++ b/src/censo/properties/uvvis.py
@@ -38,7 +38,9 @@ def uvvis(
     """
     printf(h2("UVVIS"))
 
-    config = PartsConfig.model_validate(config, context={"check": ["uvvis"]})
+    config = PartsConfig.model_validate(
+        config.model_dump(), context={"check": ["uvvis"]}
+    )
 
     # Assert that all conformers have energies defined
     # TODO: this is not optimal since == 0 does not mean that no ensembleopt has been performed before

--- a/test/unit/test_config/test_parts.py
+++ b/test/unit/test_config/test_parts.py
@@ -12,7 +12,7 @@ from censo.config.parts import (
     NMRConfig,
     UVVisConfig,
 )
-from censo.params import OrcaSolvMod, TmSolvMod, QmProg
+from censo.params import GfnVersion, OrcaSolvMod, TmSolvMod, QmProg
 
 
 def test_parts_config_default_initialization():
@@ -311,3 +311,15 @@ def test_context_specific_path_validation_for_all_parts():
             PartsConfig.model_validate(
                 config, context={"check": ["rot"], "check_sm": False}
             )
+
+
+def test_prescreening_gxtb_rejected_without_gas_phase():
+    """Test that prescreening with gfnv='gxtb' is rejected when gas_phase is False."""
+    config = PartsConfig()
+    config.general.gas_phase = False
+    config.prescreening.gfnv = GfnVersion.GXTB
+
+    with pytest.raises(ValueError, match="gxtb does not support solvation"):
+        PartsConfig.model_validate(
+            config, context={"check": ["prescreening"], "check_paths": False}
+        )


### PR DESCRIPTION
This pull request primarily improves how the configuration system handles the new `gxtb` GFN version, especially regarding solvation support. It enforces that `gxtb` cannot be used with solvation (i.e., when not in gas phase), provides user warnings and error handling for this case, and ensures consistent validation logic throughout the codebase. Additionally, it introduces the `gxtb` option in the `GfnVersion` enum and adds a corresponding unit test.

**Support and validation for `gxtb` GFN version:**

* Added `GXTB` to the `GfnVersion` enum in `params.py`, enabling its use in configuration.
* Updated `_parts_check` in `parts_config.py` to raise an error if `gxtb` is selected for prescreening with solvation, and to warn users if `gxtb` is used with solvation in other contexts.
* Modified `xtb_processor.py` to skip adding solvent for `gxtb` and to prevent running solvation calculations with `gxtb`, returning an error instead. [[1]](diffhunk://#diff-4d05c6be8dcc4d9d8f6977c7d8495f657a8e7ad766db26083554ca70e389966fL113-R114) [[2]](diffhunk://#diff-4d05c6be8dcc4d9d8f6977c7d8495f657a8e7ad766db26083554ca70e389966fR180-R188) [[3]](diffhunk://#diff-4d05c6be8dcc4d9d8f6977c7d8495f657a8e7ad766db26083554ca70e389966fL328-R335)

**Validation and interface consistency:**

* Standardized calls to `PartsConfig.model_validate` throughout the codebase to always use a dictionary representation (`model_dump()`), ensuring consistent validation behavior. [[1]](diffhunk://#diff-bec0cffdb9ab13e2aab7dd057d2c759fa10f76465b356717493705d1315b9933L92-R94) [[2]](diffhunk://#diff-ae2cac5b2f31f41c5ea3b590910c54ae0032f9465a99a7aaea21227a63f527f6L56-R58) [[3]](diffhunk://#diff-949e84c934f27dad6f2affc6e014089a0677e05af3d6e51555208934e592b121L48-R50) [[4]](diffhunk://#diff-1adfd2f1bd279cefe4faa5d26a7ed5212234628b3cb49d76ca06360734dfd80fL39-R41) [[5]](diffhunk://#diff-f4e122911e898f00ab17c70591a7e28c6a4568ac3d65374e67b4d3ea5b63e46eL56-R58) [[6]](diffhunk://#diff-e253e48b665f52508b6a9d6ae9a959a0ee003d28a7b89988defed95c1e4840f3L43-R43) [[7]](diffhunk://#diff-8a1ac44d68cc1b6b7a484065c7ab1f783d9b9020fa560ea58173d2431ec32f48L41-R41) [[8]](diffhunk://#diff-1645622b325efcf7b8d4763d31b0af2df6e7ab34aa9e1014d2d99aace50d250bL41-R43)

**Testing:**

* Added a unit test to ensure that using `gxtb` for prescreening with solvation raises an error, improving reliability and preventing unsupported configurations. [[1]](diffhunk://#diff-31854628011bd0e8a6672855166bcbe50ae052f20c31afc9a4f0513c829dc53dL15-R15) [[2]](diffhunk://#diff-31854628011bd0e8a6672855166bcbe50ae052f20c31afc9a4f0513c829dc53dR314-R325)