### PR TITLE
add cosmors for reranking after geom opt

### DIFF
--- a/src/censo/config/parts/optimization.py
+++ b/src/censo/config/parts/optimization.py
@@ -1,5 +1,6 @@
 from typing import Literal, Self
 from pydantic import model_validator, Field
+import warnings
 
 from .base import BasePartConfig
 from ...params import GfnVersion, QmProg, TmSolvMod, OrcaSolvMod
@@ -18,8 +19,18 @@ class OptimizationConfig(BasePartConfig):
     basis: str = "def2-mTZVPP"
     """Basis set that should be used for calculations."""
 
-    sm: OrcaSolvMod | Literal[TmSolvMod.DCOSMORS, TmSolvMod.COSMO] = TmSolvMod.DCOSMORS
-    """Solvation model that should be used for calculations."""
+    sm: OrcaSolvMod | TmSolvMod = TmSolvMod.DCOSMORS
+    """Solvation model that should be used for calculations.
+
+    When cosmors or cosmors-fine is chosen, geometry optimizations will use dcosmors
+    and a final gsolv calculation with the chosen COSMO-RS model will be performed
+    after all geometries are done optimizing, for final reranking.
+    """
+
+    gsolv_included: bool = False
+    """Whether to explicitly calculate Gsolv contributions
+    (False means gsolv will be calculated, True means it is already included in energy).
+    """
 
     gfnv: GfnVersion = GfnVersion.GFN2
     """GFN version to be used for xtb calculations."""
@@ -85,4 +96,22 @@ class OptimizationConfig(BasePartConfig):
             raise ValueError(
                 "Constraints can currently only be used with ANCOPT. Enable xtb_opt to use constraints."
             )
+        return self
+
+    @model_validator(mode="after")
+    def cosmors_uses_dcosmors_for_opt(self) -> Self:
+        """
+        When cosmors or cosmors-fine is chosen as solvent model, geometry optimizations
+        will use dcosmors. Warn the user and set gsolv_included to False so that a
+        final gsolv calculation with the chosen COSMO-RS model is performed for reranking.
+
+        :return: The validated instance.
+        """
+        if self.sm in [TmSolvMod.COSMORS, TmSolvMod.COSMORS_FINE]:
+            warnings.warn(
+                f"Solvation model {self.sm.value} selected for optimization. "
+                f"Geometry optimizations will use dcosmors, with a final reranking "
+                f"after all geometries are done optimizing using {self.sm.value}."
+            )
+            self.gsolv_included = False
         return self

--- a/src/censo/ensembleopt/optimization.py
+++ b/src/censo/ensembleopt/optimization.py
@@ -15,10 +15,15 @@ from ..ensemble import EnsembleData
 from ..molecules import MoleculeData, Contributions
 from ..processing import QmProc, XtbProc
 from ..parallel import execute
-from ..params import AU2KCAL, PLENGTH, GridLevel, Prog
+from ..params import AU2KCAL, PLENGTH, GridLevel, Prog, TmSolvMod
 from ..config import PartsConfig
 from ..config.parts import OptimizationConfig
-from ..config.job_config import RRHOJobConfig, OptJobConfig, XTBOptJobConfig
+from ..config.job_config import (
+    RRHOJobConfig,
+    OptJobConfig,
+    SPJobConfig,
+    XTBOptJobConfig,
+)
 from ..utilities import (
     printf,
     h1,
@@ -57,13 +62,27 @@ def optimization(
         config.model_dump(), context={"check": ["optimization"]}
     )
 
+    # When cosmors/cosmors-fine is selected, create a config copy with sm=dcosmors
+    # for geometry optimization (cosmors cannot compute gradients), then use the
+    # original config for gsolv reranking with the chosen COSMO-RS model.
+    if config.optimization.sm in [TmSolvMod.COSMORS, TmSolvMod.COSMORS_FINE]:
+        opt_config = config.model_copy(
+            update={
+                "optimization": config.optimization.model_copy(
+                    update={"sm": TmSolvMod.DCOSMORS}
+                )
+            }
+        )
+    else:
+        opt_config = config
+
     # Setup processor
     proc = Factory[QmProc].create(config.optimization.prog, "2_OPTIMIZATION")
 
     if config.optimization.macrocycles:
-        contributions_dict = _macrocycle_opt(proc, ensemble, config, client, cut)
+        contributions_dict = _macrocycle_opt(proc, ensemble, opt_config, client, cut)
     else:
-        contributions_dict = _full_opt(proc, ensemble, config, client=client)
+        contributions_dict = _full_opt(proc, ensemble, opt_config, client=client)
 
     printf("\n")
 
@@ -93,6 +112,45 @@ def optimization(
 
         for conf in ensemble:
             contributions_dict[conf.name].grrho = results[conf.name].energy
+
+    # When cosmors or cosmors-fine is chosen as solvent model, geometry optimizations
+    # used dcosmors, so now we compute gsolv with the chosen COSMO-RS model for final reranking
+    if not config.general.gas_phase and (
+        config.optimization.sm in [TmSolvMod.COSMORS, TmSolvMod.COSMORS_FINE]
+        or not config.optimization.gsolv_included
+    ):
+        printf(f"Reranking using {config.optimization.sm}.")
+
+        gsolv_job_config = SPJobConfig(
+            copy_mo=config.general.copy_mo,
+            func=config.optimization.func,
+            basis=config.optimization.basis,
+            grid=GridLevel.HIGH,
+            template=config.optimization.template,
+            gas_phase=False,
+            solvent=config.general.solvent,
+            sm=config.optimization.sm,
+            temperature=config.general.temperature,
+            paths=config.paths,
+        )
+
+        gsolv_results = execute(
+            ensemble.conformers,
+            proc.gsolv,
+            gsolv_job_config,
+            config.optimization.prog,
+            "optimization",
+            client,
+            ignore_failed=config.general.ignore_failed,
+            balance=config.general.balance,
+            copy_mo=config.general.copy_mo,
+        )
+
+        if config.general.ignore_failed:
+            ensemble.remove_conformers(lambda conf: conf.name not in gsolv_results)
+
+        for conf in ensemble:
+            contributions_dict[conf.name].gsolv = gsolv_results[conf.name].gsolv
 
     ensemble.update_contributions(contributions_dict)
 

--- a/src/censo/utilities.py
+++ b/src/censo/utilities.py
@@ -231,7 +231,9 @@ def get_time(time: float) -> tuple[int, int, int]:
 
 def h1(text: str) -> str:
     """
-    Create a formatted header of type 1.
+    Create a formatted header of type 1:
+
+    --- text ---
 
     :param text: The text to be formatted.
     :return: The formatted header.
@@ -241,7 +243,11 @@ def h1(text: str) -> str:
 
 def h2(text: str) -> str:
     """
-    Create a formatted header of type 2.
+    Create a formatted header of type 2:
+
+    ---
+    text
+    ---
 
     :param text: The text to be formatted.
     :return: The formatted header.

--- a/test/unit/test_config/test_optimization.py
+++ b/test/unit/test_config/test_optimization.py
@@ -69,7 +69,15 @@ def test_invalid_optlevel():
 
 
 @pytest.mark.parametrize(
-    "sm", [TmSolvMod.DCOSMORS, TmSolvMod.COSMO, OrcaSolvMod.CPCM, OrcaSolvMod.SMD]
+    "sm",
+    [
+        TmSolvMod.DCOSMORS,
+        TmSolvMod.COSMO,
+        TmSolvMod.COSMORS,
+        TmSolvMod.COSMORS_FINE,
+        OrcaSolvMod.CPCM,
+        OrcaSolvMod.SMD,
+    ],
 )
 def test_valid_solvent_models(sm):
     """Test valid solvent model combinations"""
@@ -77,10 +85,10 @@ def test_valid_solvent_models(sm):
     assert config.sm == sm
 
 
-def test_invalid_solvent_model():
-    """Test invalid solvent model"""
-    with pytest.raises(ValueError):
-        OptimizationConfig(sm=TmSolvMod.COSMORS)  # type: ignore[arg-type]
+def test_default_gsolv_included():
+    """Test default gsolv_included is False"""
+    config = OptimizationConfig()
+    assert config.gsolv_included is False
 
 
 @pytest.mark.parametrize(
@@ -101,6 +109,33 @@ def test_functional_validation(prog, func, should_pass):
     else:
         with pytest.raises(ValueError):
             OptimizationConfig(prog=prog, func=func)
+
+
+def test_cosmors_solvent_model_sets_gsolv_included():
+    """Test that cosmors/cosmors-fine sets gsolv_included to False and warns about dcosmors"""
+    import warnings as w
+
+    for sm in [TmSolvMod.COSMORS, TmSolvMod.COSMORS_FINE]:
+        with w.catch_warnings(record=True) as caught:
+            w.simplefilter("always")
+            config = OptimizationConfig(sm=sm)
+            assert config.sm == sm
+            assert config.gsolv_included is False
+            # Should warn that geometry optimizations will use dcosmors
+            assert any("dcosmors" in str(c.message) for c in caught)
+
+
+def test_dcosmors_solvent_model_does_not_warn_or_change_gsolv_included():
+    """Test that dcosmors does not trigger the cosmors warning and gsolv_included stays default"""
+    import warnings as w
+
+    with w.catch_warnings(record=True) as caught:
+        w.simplefilter("always")
+        config = OptimizationConfig(sm=TmSolvMod.DCOSMORS)
+        assert config.sm == TmSolvMod.DCOSMORS
+        assert config.gsolv_included is False
+        # dcosmors should NOT produce a warning about using dcosmors for optimization
+        assert not any("dcosmors" in str(c.message) for c in caught)
 
 
 def test_constraints_validation():


### PR DESCRIPTION
This pull request improves the handling of COSMO-RS solvent models in geometry optimizations, ensuring that when `cosmors` or `cosmors-fine` is selected, geometry optimizations are performed with `dcosmors` and a final reranking is done using the chosen COSMO-RS model. It also adds related configuration options, updates reranking logic, and expands test coverage for these behaviors.

**COSMO-RS solvent model handling:**

* Updated `OptimizationConfig` to support `COSMORS` and `COSMORS_FINE` as valid solvent models, added a `gsolv_included` option, and implemented logic to warn users and set `gsolv_included` to `False` when these models are selected. Geometry optimizations will use `dcosmors`, with a final reranking using the selected COSMO-RS model. [[1]](diffhunk://#diff-32b339d7a2961661db70ac2cde64aea1fe83179d16257a7e59aa2fd1e2281d30L21-R33) [[2]](diffhunk://#diff-32b339d7a2961661db70ac2cde64aea1fe83179d16257a7e59aa2fd1e2281d30R100-R117)
* In the `optimization` workflow, when `COSMORS` or `COSMORS_FINE` is chosen, geometry optimization is performed with `dcosmors`, and a final single-point calculation is run with the selected COSMO-RS model for reranking. [[1]](diffhunk://#diff-ae2cac5b2f31f41c5ea3b590910c54ae0032f9465a99a7aaea21227a63f527f6R65-R85) [[2]](diffhunk://#diff-ae2cac5b2f31f41c5ea3b590910c54ae0032f9465a99a7aaea21227a63f527f6R116-R154)

**Testing improvements:**

* Added tests to verify that `gsolv_included` is set to `False` and the appropriate warning is issued for COSMO-RS models, and that no warning is issued for `dcosmors`. Also added a test for the default value of `gsolv_included`. [[1]](diffhunk://#diff-f2502a9399b2fe74bbeaa2dd693658fc0ca46e7f9ddcf1a491dd0d862f5b28a7L72-R91) [[2]](diffhunk://#diff-f2502a9399b2fe74bbeaa2dd693658fc0ca46e7f9ddcf1a491dd0d862f5b28a7R114-R140)

**Documentation and minor improvements:**

* Improved docstrings for header formatting utilities `h1` and `h2` for clarity. [[1]](diffhunk://#diff-31d213ffef315e896f891d03ec050f93f0f7e69ee313e2079699a4b9b893109aL234-R236) [[2]](diffhunk://#diff-31d213ffef315e896f891d03ec050f93f0f7e69ee313e2079699a4b9b893109aL244-R250)